### PR TITLE
Fix undocumented date parameter required by airnow.

### DIFF
--- a/index.js
+++ b/index.js
@@ -243,7 +243,7 @@ module.exports = function(options){
 			
 			// reformat the date to the expected format of airnow API
 			if (_.has(options, "date")){
-				options.date = moment(options.date).format("YYYY-MM-DD") + 'T00-0000';
+				options.date = moment(options.date).format("YYYY-MM-DDTHHZ");
 			}
 			
 			// send with brute force retry
@@ -282,7 +282,7 @@ module.exports = function(options){
 			
 			// reformat the date to the expected format of airnow API
 			if (_.has(options, "date")){
-				options.date = moment(options.date).format("YYYY-MM-DD") + 'T00-0000';
+				options.date = moment(options.date).format("YYYY-MM-DDTHHZ");
 			}
 			
 			// send with brute force retry

--- a/index.js
+++ b/index.js
@@ -243,7 +243,7 @@ module.exports = function(options){
 			
 			// reformat the date to the expected format of airnow API
 			if (_.has(options, "date")){
-				options.date = moment(options.date).format("YYYY-MM-DD")
+				options.date = moment(options.date).format("YYYY-MM-DD") + 'T00-0000';
 			}
 			
 			// send with brute force retry
@@ -282,7 +282,7 @@ module.exports = function(options){
 			
 			// reformat the date to the expected format of airnow API
 			if (_.has(options, "date")){
-				options.date = moment(options.date).format("YYYY-MM-DD")
+				options.date = moment(options.date).format("YYYY-MM-DD") + 'T00-0000';
 			}
 			
 			// send with brute force retry


### PR DESCRIPTION
Airnow was throwing an error about incorrect date format. Looked at their documents, didn't help, but their query builder showed the format added 'T00-0000' for only the historical queries. I'm *guessing* it's THHZ, which seems the most logical. Not sure if this was a recent change, or if this never worked!